### PR TITLE
Fixing importing issue.

### DIFF
--- a/xmlrunner/__init__.py
+++ b/xmlrunner/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from xmlrunner import XMLTestRunner
+from .xmlrunner import XMLTestRunner
 


### PR DESCRIPTION
This fixes importing the package, since the module name and the package name are the same.

I couldn't import the version I installed through pip (nor the one cloned from the repository), with Python complaining about being unable to import the name XMLTestRunner. Turns out that since the package's name and the module's name are the same, it tries to import from itself, where it, clearly, doesn't exist. The '.' resolves to the module as should.
