### PR TITLE
PyPI Distribution Sub-Package Fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python
 
-import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 from xmlrunner.version import __version__
 
 setup(
-    name = 'xmlrunner',
-    version = __version__,
-    author = 'Daniel Fernandes Martins',
-    author_email = 'daniel.tritone@gmail.com',
-    description = 'PyUnit-based test runner with JUnit like XML reporting.',
-    license = 'LGPL',
-    platforms = ['Any'],
-    keywords = ['pyunit', 'unittest', 'junit xml', 'report', 'testrunner'],
-    url = 'https://github.com/pycontribs/xmlrunner',
-    classifiers = [
+    name='xmlrunner',
+    version=__version__,
+    author='Daniel Fernandes Martins',
+    author_email='daniel.tritone@gmail.com',
+    description='PyUnit-based test runner with JUnit like XML reporting.',
+    license='LGPL',
+    platforms=['Any'],
+    keywords=['pyunit', 'unittest', 'junit xml', 'report', 'testrunner'],
+    url='https://github.com/pycontribs/xmlrunner',
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
@@ -27,9 +26,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing'
     ],
-    packages = ['xmlrunner', 'xmlrunner.tests', 'xmlrunner.extra'],
-    provides = ['xmlrunner'],
-    zip_safe = True,
-    include_package_data = True,
-    test_suite = 'xmlrunner.tests.test_xmlrunner'
+    packages=['xmlrunner', 'xmlrunner.tests', 'xmlrunner.extra'],
+    provides=['xmlrunner'],
+    zip_safe=True,
+    include_package_data=True,
+    test_suite='xmlrunner.tests.test_xmlrunner'
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing'
     ],
-    packages = ['xmlrunner'],
+    packages = ['xmlrunner', 'xmlrunner.tests', 'xmlrunner.extra'],
     provides = ['xmlrunner'],
     zip_safe = True,
     include_package_data = True,

--- a/xmlrunner/__init__.py
+++ b/xmlrunner/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from .xmlrunner import XMLTestRunner
-
+import extra
+import tests

--- a/xmlrunner/extra/__init__.py
+++ b/xmlrunner/extra/__init__.py
@@ -1,0 +1,5 @@
+try:
+    import djangotestrunner
+except ImportError:
+    # Django is not installed.
+    pass

--- a/xmlrunner/extra/djangotestrunner.py
+++ b/xmlrunner/extra/djangotestrunner.py
@@ -4,17 +4,15 @@
 Custom Django test runner that runs the tests using the
 XMLTestRunner class.
 
-This script shows how to use the XMLTestRunner in a Django project. To learn
-how to configure a custom TestRunner in a Django project, please read the
-Django docs website.
+Usage of this class requires Django to be installed and is intended as a test
+suite runner for Django projects. To learn how to configure a custom TestRunner
+in a Django project, please read the Django docs website.
 """
-import os
 from django.conf import settings
 from django.test.simple import DjangoTestSuiteRunner
 from django.test.utils import setup_test_environment, teardown_test_environment
 import xmlrunner
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'mysite.settings'
 
 class XMLTestRunner(DjangoTestSuiteRunner):
     def run_tests(self, test_labels, extra_tests=None, **kwargs):

--- a/xmlrunner/tests/__init__.py
+++ b/xmlrunner/tests/__init__.py
@@ -1,0 +1,1 @@
+import test_xmlrunner


### PR DESCRIPTION
This resolves #4 by including the `tests` and `extra` packages with the PyPI distribution.

There were two ways of fixing this:
1. Add `xmlrunner.extra` and `xmlrunner.tests` to the `packages` list in `setup.py`, and
2. Add import statements to appropriate `__init__.py` files leaving breadcrumbs for `distutils` to follow and implicitly include the sub-packages in the distribution installation.

I included both of these fixes, the first because "explicit is better than implicit" and the second to make it easier to import these sub-packages.

I also took the opportunity to make `setup.py` compatible with PEP8 (just removing the spaces between the keyword arguments in the `setup()` function) and to make `djangotestrunner` a fully usable out-of-the-box module. Previously, it seemed to have been an example script, even including the line

```
os.environ['DJANGO_SETTINGS_MODULE'] = 'mysite.settings'
```

which was too generic to be applied to an actual Django project environment. The module can now be used as mentioned in the README (I think).

Let me know if anything is not to your liking.
