### PR TITLE
Added support for python 3.12

### DIFF
--- a/xmlrunner/xmlrunner.py
+++ b/xmlrunner/xmlrunner.py
@@ -14,7 +14,7 @@ try:
     from unittest2.runner import TextTestResult as _TextTestResult
     from unittest2.result import TestResult
 except ImportError:
-    from unittest import TestResult, _TextTestResult, TextTestRunner
+    from unittest import TestResult, TextTestResult as _TextTestResult, TextTestRunner
 
 try:
     # Removed in Python 3


### PR DESCRIPTION
Removed reference to deprecated class in python 3.11 `_TextTestResult`